### PR TITLE
SNS認証（facebook/google）によるユーザ登録・ログイン機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_item_detail.scss
+++ b/app/assets/stylesheets/modules/_item_detail.scss
@@ -321,9 +321,6 @@ main.itemdetail-background{
                     margin-top: 10px;
                     &__member{
                         display: flex;
-                        ul{
-
-                        }
                     }
                 }
             }

--- a/app/assets/stylesheets/modules/_item_sending_destination.scss
+++ b/app/assets/stylesheets/modules/_item_sending_destination.scss
@@ -358,8 +358,5 @@
     &__logo{
       padding: 20px 0 0;
     }
-    &__copy{
-
-    }
   }
 }

--- a/app/assets/stylesheets/modules/_registration.scss
+++ b/app/assets/stylesheets/modules/_registration.scss
@@ -281,7 +281,6 @@
                     transition: all ease-out .3s;
                     cursor: pointer;
                     text-align: center;
-                    vertical-align: middle;
                     &-cian{
                         margin-top: 32px;
                         margin: 16px 0 0;
@@ -460,9 +459,6 @@
         }
         &__logo{
           padding: 20px 0 0;
-        }
-        &__copy{
-    
         }
       }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -110,6 +110,7 @@ class ItemsController < ApplicationController
   end
 
   def set_card
+    redirect_to user_session_path and return unless user_signed_in?
     @card = Card.find_by(user_id: current_user.id)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,18 +1,20 @@
 class UsersController < ApplicationController
-    before_action :set_parents, only: [:show]
+  before_action :redirect_if_signed_out, except: [:new]  
+  before_action :set_parents, only: [:show]
 
     def new
     end
 
     def show
-      if not request.referrer
-        redirect_to root_path
-        return
-      end
       @user = User.includes(:sending_destination, :profile).find(current_user.id)
     end
 
     def favorites
       Favorite.find_by(user_id: current_user.id, item_id: params[:item_id])
+    end
+
+    private
+    def redirect_if_signed_out
+      redirect_to root_path and return unless request.referrer && user_signed_in?
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+
+
+  
     before_action :redirect_if_signed_out, except: [:new]  
     before_action :set_parents, only: [:show, :favorites]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,4 @@
 class UsersController < ApplicationController
-
-
-  
     before_action :redirect_if_signed_out, except: [:new]  
     before_action :set_parents, only: [:show, :favorites]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :redirect_if_signed_out, except: [:new]  
-  before_action :set_parents, only: [:show]
+    before_action :redirect_if_signed_out, except: [:new]  
+    before_action :set_parents, only: [:show, :favorites]
 
     def new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-    before_action :redirect_if_signed_out, except: [:new]  
-    before_action :set_parents, only: [:show, :favorites]
+before_action :redirect_if_signed_out, except: [:new]  
+before_action :set_parents, only: [:show, :favorites]
 
     def new
     end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,9 @@
 = render 'items/header'
-- if @seller.id == current_user.id
-  = render 'items/itemdetail_forseller'
+- if user_signed_in?
+  - if @seller.id == current_user.id
+    = render 'items/itemdetail_forseller'
+  - else
+    = render 'items/itemdetail_forbuyer'
 - else
   = render 'items/itemdetail_forbuyer'
 = render 'items/appbanner'

--- a/spec/models/facebook_validation_spec.rb
+++ b/spec/models/facebook_validation_spec.rb
@@ -13,10 +13,25 @@ RSpec.describe SnsCredential, type: :model do
         before do
           SnsCredential.create(provider: 'google_oauth2', uid: '12345', user_id: '1')
         end
-          example 'uidのvalidation(unique制約）が機能するか' do
-            expect(SnsCredential.create(provider: 'facebook', uid: '12345', user_id: '1').errors[:uid]).to include('はすでに登録されています')
-          end         
+        example 'uidのvalidation(unique制約）が機能するか' do
+          expect(SnsCredential.create(provider: 'facebook', uid: '12345', user_id: '1').errors[:uid]).to include('はすでに登録されています')
+        end         
       end
     end
+
+    context '認可サーバーから返ってきたメールアドレスを、すでに登録済みのuserが持っていた場合' do
+        before do
+          user = create(:user, email: 'sample@test.com')
+        end
+        context '認可サーバーから帰ってきた情報とprovider名が同じだが、同じuidを持つSnsCredentialレコードがない場合' do
+          before do
+            SnsCredential.create(provider: 'facebook', uid: '12345', user_id: '1')
+          end
+          example 'credentialが登録できるか' do
+            expect(SnsCredential.create(provider: 'facebook', uid: '000000', user_id: '1')).to be_valid
+          end         
+        end
+    end
+
   end
 end


### PR DESCRIPTION
# What
## サーバサイド
- facebook / google_oauth2のapiを使って新規会員登録ができる

- SNS認証時はnickname、emailを自動補完し、password入力は不要
![a60a2c3ad7e701069832420f3844109c](https://user-images.githubusercontent.com/35995190/90308064-2965ca00-df17-11ea-9dd5-88e503d026cd.gif)

- ログイン画面上のSNS認証ボタンでemail、password入力不要でログイン可能
![b6d4c15de72f266337e29825897ab297](https://user-images.githubusercontent.com/35995190/90308066-35518c00-df17-11ea-97c3-94c6aca959bd.gif)

- sns_credentialモデルを定義し、provider, uid, user_idフィールドを作成
- Userモデルに定義したfrom_oauthメソッドがapiからのレスポンス処理を行う

## テスト
- sns_credentialモデルの単体テスト、およびUserモデルのfrom_oauthメソッドの機能テストを実施
<img width="878" alt="70bc494d8b3a43b6b50b6ca4e01508bc" src="https://user-images.githubusercontent.com/35995190/90308046-0e935580-df17-11ea-8edd-44e34804277f.png">



# Why
- 近年のウェブアプリではSNS認証がほぼ標準となっているため