### PR TITLE
検索機能L2 >カテゴリコントローラ修正

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,6 @@
 class CategoriesController < ApplicationController
   before_action :set_category, only: :show
-  before_action :set_parents, only: :show
-  before_action :search_params, only: :show
+  before_action :set_parents, only: [:index, :show]
 
   def show
     # @items = @category.items の記述では、@categoryが孫の場合しか商品情報を取得出来ないため、モデルメソッド set_itemsにより、カテゴリー内の適切な商品を取得する


### PR DESCRIPTION
# What
カテゴリ一一覧ページが表示されないエラーの修正

categories_coontroller.rb
・search_params削除
　→applicationで共通呼び出し処理をしているため削除
・set_parentsにindexの呼び出しを追加
　→indexアクションが呼び出されない処理（only :show）となっていたため、indexの呼び出しを追加した

# Why
カテゴリ一一覧ページが正常に表示されるよう修正