### PR TITLE
Update favorites.html.haml

### DIFF
--- a/app/views/users/favorites.html.haml
+++ b/app/views/users/favorites.html.haml
@@ -16,9 +16,10 @@
                   .mypage__productSold
                     .mypage__productSold__inner
                       SOLD
-                - item.item_imgs.each do |item_img|
-                  = image_tag item_img.url.url
-
+                - item.item_imgs.each_with_index do |item_img, i|
+                  -# 配列の先頭の画像のみ表示
+                  -if i == 0
+                    = image_tag item_img.url.url
               .mypage__favContent__content__body
                 %h3.mypage__favContent__content__body--name
                   = item.name


### PR DESCRIPTION
# What
マイページ > いいね一覧ページ
複数写真が登録されてる商品において、配列の先頭の画像のみ表示

# Why
複数写真が表示されレイアウト崩れが起きていたため、上記修正した
